### PR TITLE
Fix router warning by respecting base URL

### DIFF
--- a/ki-stammbaum/nuxt.config.ts
+++ b/ki-stammbaum/nuxt.config.ts
@@ -3,4 +3,9 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-05-15',
   devtools: { enabled: true },
   modules: ['@pinia/nuxt'],
+  app: {
+    // Allow hosting the app in a sub-directory by respecting the
+    // NUXT_APP_BASE_URL environment variable. Defaults to '/'.
+    baseURL: process.env.NUXT_APP_BASE_URL || '/',
+  },
 });

--- a/ki-stammbaum/pages/index.vue
+++ b/ki-stammbaum/pages/index.vue
@@ -10,7 +10,11 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 
-const { data: treeData, pending, error } = await useFetch('/data/ki-stammbaum.json');
+// Use runtime config so the fetch path respects the app base URL.
+const config = useRuntimeConfig();
+const { data: treeData, pending, error } = await useFetch('data/ki-stammbaum.json', {
+  baseURL: config.app.baseURL,
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- respect `NUXT_APP_BASE_URL` in Nuxt config so the app can run from a sub directory
- use runtime config in the data fetch to build the request URL

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684aa1bfede48329aa209ac08b967a3b