### PR TITLE
Implement graph-transform helper

### DIFF
--- a/ki-stammbaum/types/concept.d.ts
+++ b/ki-stammbaum/types/concept.d.ts
@@ -1,0 +1,22 @@
+export interface Concept {
+  id: string;
+  name: string;
+  year: number;
+  description: string;
+  dependencies: string[];
+}
+
+export interface Node {
+  id: string;
+  year: number;
+}
+
+export interface Link {
+  source: string;
+  target: string;
+}
+
+export interface Graph {
+  nodes: Node[];
+  links: Link[];
+}

--- a/ki-stammbaum/utils/graph-transform.ts
+++ b/ki-stammbaum/utils/graph-transform.ts
@@ -1,0 +1,23 @@
+/**
+ * Utility functions for transforming the KI-Stammbaum dataset into
+ * a D3-compatible format.
+ * @module graph-transform
+ * @author KI-Stammbaum
+ */
+
+import type { Concept, Graph, Node, Link } from '../types/concept';
+
+/**
+ * Converts a list of concepts into nodes and links for D3.
+ * @param concepts - Preprocessed concepts from the JSON file.
+ * @returns Object containing arrays of nodes and links.
+ */
+export function transformToGraph(concepts: Concept[]): Graph {
+  // 1 Nodes erstellen – jedes Konzept wird zum Knoten
+  const nodes: Node[] = concepts.map((c) => ({ id: c.id, year: +c.year }));
+  // 2 Links erstellen – Abhängigkeiten bilden gerichtete Kanten
+  const links: Link[] = concepts.flatMap((c) =>
+    (c.dependencies ?? []).map((dep) => ({ source: dep, target: c.id })),
+  );
+  return { nodes, links };
+}


### PR DESCRIPTION
## Summary
- add TypeScript types for concepts and graph structure
- convert a concept array into D3 nodes and links

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_684aa6e172688329845dfe654c18a873