### PR TITLE
Add stammbaum page using new data composable

### DIFF
--- a/ki-stammbaum/composables/useStammbaumData.ts
+++ b/ki-stammbaum/composables/useStammbaumData.ts
@@ -1,0 +1,34 @@
+import { shallowRef } from 'vue';
+
+interface StammbaumData {
+  nodes: any[];
+  [key: string]: any;
+}
+
+const dataCache = shallowRef<StammbaumData | null>(null);
+const pendingCache = shallowRef(false);
+const errorCache = shallowRef<Error | null>(null);
+
+async function loadData() {
+  if (dataCache.value || pendingCache.value) return;
+  pendingCache.value = true;
+  try {
+    dataCache.value = await $fetch<StammbaumData>('/data/ki-stammbaum.json');
+  } catch (err) {
+    errorCache.value = err as Error;
+  } finally {
+    pendingCache.value = false;
+  }
+}
+
+export function useStammbaumData() {
+  if (!dataCache.value && !pendingCache.value) {
+    // Fire and forget; composable consumers can watch pending.
+    loadData();
+  }
+  return {
+    data: dataCache,
+    pending: pendingCache,
+    error: errorCache,
+  };
+}

--- a/ki-stammbaum/pages/stammbaum.vue
+++ b/ki-stammbaum/pages/stammbaum.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="stammbaum-page">
+    <h1>KI-Stammbaum</h1>
+
+    <FilterControls @filtersApplied="onFilters" />
+
+    <div v-if="pending">Daten werden geladen...</div>
+    <div v-else-if="error">Fehler beim Laden: {{ error.message }}</div>
+    <KiStammbaum
+      v-else
+      :data="graphData"
+      @conceptSelected="selectConcept"
+    />
+
+    <ConceptDetail :concept="selected" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import KiStammbaum from '@/components/KiStammbaum.vue';
+import FilterControls from '@/components/FilterControls.vue';
+import ConceptDetail from '@/components/ConceptDetail.vue';
+import { useStammbaumData } from '@/composables/useStammbaumData';
+
+const { data, pending, error } = useStammbaumData();
+const selected = ref(null);
+
+function selectConcept(concept: any) {
+  selected.value = concept;
+}
+
+function onFilters(filters: any) {
+  // Filterlogik kann hier später integriert werden
+  console.log('angewandte Filter', filters);
+}
+
+const graphData = computed(() => data.value?.nodes || []);
+</script>
+
+<style scoped>
+.stammbaum-page {
+  padding: 1rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- add composable `useStammbaumData` for loading `/data/ki-stammbaum.json`
- create `pages/stammbaum.vue` to render the main visualization with `KiStammbaum`
- integrate `FilterControls` and `ConceptDetail` placeholders on the new page

## Testing
- `pnpm lint` *(fails: Error when performing the request)*

------
https://chatgpt.com/codex/tasks/task_e_684aa6e1050c832980e8e0337a193d12