### PR TITLE
Implement Legend and modal components

### DIFF
--- a/ki-stammbaum/components/ConceptDetail.vue
+++ b/ki-stammbaum/components/ConceptDetail.vue
@@ -1,18 +1,18 @@
 <template>
-  <div v-if="concept" class="concept-detail-container">
-    <h2>Konzeptdetails</h2>
-    <p><strong>Name:</strong> {{ concept.name }}</p>
-    <p><strong>Jahr:</strong> {{ concept.year }}</p>
-    <p><strong>Beschreibung:</strong> {{ concept.description }}</p>
-    <!-- Weitere Details hier -->
-  </div>
-  <div v-else class="concept-detail-placeholder">
-    <p>Wählen Sie ein Konzept aus, um Details anzuzeigen.</p>
-  </div>
+  <BaseModal :open="!!concept" @close="close">
+    <div v-if="concept" class="concept-detail-container">
+      <h2>Konzeptdetails</h2>
+      <p><strong>Name:</strong> {{ concept.name }}</p>
+      <p><strong>Jahr:</strong> {{ concept.year }}</p>
+      <p><strong>Beschreibung:</strong> {{ concept.description }}</p>
+      <button class="close-button" type="button" @click="close">Schließen</button>
+    </div>
+  </BaseModal>
 </template>
 
 <script setup lang="ts">
-import { defineProps } from 'vue';
+import { defineProps, defineEmits } from 'vue';
+import BaseModal from './ui/BaseModal.vue';
 
 // Define the structure of a concept, aligning with KiConcept if possible
 interface KiConcept {
@@ -27,8 +27,14 @@ const props = defineProps({
   concept: {
     type: Object as () => KiConcept | null,
     default: null,
-  }
+  },
 });
+
+const emit = defineEmits(['close']);
+
+function close() {
+  emit('close');
+}
 </script>
 
 <style scoped>
@@ -49,12 +55,4 @@ const props = defineProps({
   margin-bottom: 0.5rem;
 }
 
-.concept-detail-placeholder {
-  padding: 1rem;
-  margin-top: 1rem;
-  text-align: center;
-  color: #888;
-  border: 1px dashed #ccc;
-  border-radius: 8px;
-}
 </style>

--- a/ki-stammbaum/components/Legend.vue
+++ b/ki-stammbaum/components/Legend.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="legend">
+    <h3>Legende</h3>
+    <ul>
+      <li v-for="c in categories" :key="c.name" class="legend-item">
+        <span class="color-box" :style="{ backgroundColor: c.color }" />
+        {{ c.name }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+/** Legend component displaying node types with their colors. */
+export interface LegendCategory {
+  name: string;
+  color: string;
+}
+
+const props = defineProps<{ categories: LegendCategory[] }>();
+</script>
+
+<style scoped>
+.legend {
+  margin-top: 1rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+
+.color-box {
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.5rem;
+  border-radius: 2px;
+  border: 1px solid #ccc;
+}
+</style>

--- a/ki-stammbaum/components/ui/BaseModal.vue
+++ b/ki-stammbaum/components/ui/BaseModal.vue
@@ -1,0 +1,56 @@
+<template>
+  <teleport to="body">
+    <div v-if="open" class="modal-overlay" @click.self="close">
+      <div class="modal-content" role="dialog">
+        <button class="modal-close" aria-label="Schließen" type="button" @click="close">×</button>
+        <slot />
+      </div>
+    </div>
+  </teleport>
+</template>
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue';
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(['close']);
+
+function close() {
+  emit('close');
+}
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  position: relative;
+  max-width: 90%;
+  max-height: 90%;
+  overflow: auto;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+</style>

--- a/ki-stammbaum/pages/stammbaum.vue
+++ b/ki-stammbaum/pages/stammbaum.vue
@@ -3,6 +3,7 @@
     <h1>KI-Stammbaum</h1>
 
     <FilterControls @filtersApplied="onFilters" />
+    <Legend :categories="legendCategories" />
 
     <div v-if="pending">Daten werden geladen...</div>
     <div v-else-if="error">Fehler beim Laden: {{ error.message }}</div>
@@ -12,7 +13,7 @@
       @conceptSelected="selectConcept"
     />
 
-    <ConceptDetail :concept="selected" />
+    <ConceptDetail :concept="selected" @close="selected = null" />
   </div>
 </template>
 
@@ -21,10 +22,16 @@ import { computed, ref } from 'vue';
 import KiStammbaum from '@/components/KiStammbaum.vue';
 import FilterControls from '@/components/FilterControls.vue';
 import ConceptDetail from '@/components/ConceptDetail.vue';
+import Legend from '@/components/Legend.vue';
 import { useStammbaumData } from '@/composables/useStammbaumData';
 
 const { data, pending, error } = useStammbaumData();
 const selected = ref(null);
+const legendCategories = [
+  { name: 'Algorithmus', color: '#1f77b4' },
+  { name: 'Konzept', color: '#2ca02c' },
+  { name: 'Technologie', color: '#ff7f0e' },
+];
 
 function selectConcept(concept: any) {
   selected.value = concept;


### PR DESCRIPTION
## Summary
- add generic `BaseModal` component
- add a simple `Legend` component
- use `BaseModal` in `ConceptDetail`
- enhance the stammbaum page with the legend and close event

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684aa973728c8329ae0535e2defa815f