### PR TITLE
Add default layout and about page

### DIFF
--- a/ki-stammbaum/layouts/default.vue
+++ b/ki-stammbaum/layouts/default.vue
@@ -1,0 +1,41 @@
+<template>
+  <div>
+    <header class="site-header">
+      <nav>
+        <NuxtLink to="/">Start</NuxtLink>
+        |
+        <NuxtLink to="/stammbaum">Stammbaum</NuxtLink>
+        |
+        <NuxtLink to="/about">Über</NuxtLink>
+      </nav>
+    </header>
+    <main>
+      <slot />
+    </main>
+    <footer class="site-footer">
+      <p>&copy; 2024 KI-Stammbaum</p>
+    </footer>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Grundlayout für alle Seiten
+</script>
+
+<style scoped>
+.site-header {
+  padding: 1rem;
+  background-color: #f5f5f5;
+}
+.site-header nav a {
+  margin-right: 0.5rem;
+}
+.site-footer {
+  padding: 1rem;
+  background-color: #f5f5f5;
+  text-align: center;
+}
+main {
+  padding: 1rem;
+}
+</style>

--- a/ki-stammbaum/pages/about.vue
+++ b/ki-stammbaum/pages/about.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="about-page">
+    <h1>Über dieses Projekt</h1>
+    <p>
+      Der KI-Stammbaum visualisiert die Entwicklung der künstlichen Intelligenz.
+      Die Daten stammen aus einer kuratierten Sammlung historischer Konzepte
+      und Technologien.
+    </p>
+    <h2>Credits</h2>
+    <p>
+      Diese Demo wurde im Rahmen eines Beispielprojekts erstellt. Die
+      Visualisierung basiert auf Nuxt 3 und D3.js.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({ layout: 'default' })
+</script>
+
+<style scoped>
+.about-page h1 {
+  margin-bottom: 1rem;
+}
+</style>

--- a/ki-stammbaum/pages/index.vue
+++ b/ki-stammbaum/pages/index.vue
@@ -8,6 +8,7 @@
 </template>
 
 <script setup lang="ts">
+definePageMeta({ layout: 'default' });
   import { useStammbaumData } from '@/composables/useStammbaumData';
 
   const { data: treeData, pending, error } = useStammbaumData();

--- a/ki-stammbaum/pages/stammbaum.vue
+++ b/ki-stammbaum/pages/stammbaum.vue
@@ -17,6 +17,7 @@
 </template>
 
 <script setup lang="ts">
+definePageMeta({ layout: 'default' });
 import { computed, ref } from 'vue';
 import KiStammbaum from '@/components/KiStammbaum.vue';
 import FilterControls from '@/components/FilterControls.vue';


### PR DESCRIPTION
## Summary
- add simple default layout with header and footer
- create a basic about page with project information
- use the new layout on all existing pages

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684aa9740bd08329bfce6be96c6a13d0