### PR TITLE
Add initial Vitest setup and tests

### DIFF
--- a/ki-stammbaum/package.json
+++ b/ki-stammbaum/package.json
@@ -9,7 +9,8 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "test": "vitest"
   },
   "dependencies": {
     "@pinia/nuxt": "^0.11.1",
@@ -31,6 +32,10 @@
     "prettier": "^3.5.3",
     "prettier-eslint": "^16.4.2",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "@vitejs/plugin-vue": "^5.0.4",
+    "@vue/test-utils": "^2.4.1",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.4.0"
   }
 }

--- a/ki-stammbaum/tests/components/filter-controls.spec.ts
+++ b/ki-stammbaum/tests/components/filter-controls.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import FilterControls from '@/components/FilterControls.vue';
+
+describe('FilterControls', () => {
+  it('emits selected filters', async () => {
+    const wrapper = mount(FilterControls);
+    await wrapper.find('input').setValue('2000');
+    await wrapper.find('select').setValue('algorithm');
+    await wrapper.find('button').trigger('click');
+
+    const emitted = wrapper.emitted('filtersApplied');
+    expect(emitted).toBeTruthy();
+    expect(emitted![0][0]).toEqual({ year: 2000, type: 'algorithm' });
+  });
+});

--- a/ki-stammbaum/tests/components/ki-stammbaum.spec.ts
+++ b/ki-stammbaum/tests/components/ki-stammbaum.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import KiStammbaum from '@/components/KiStammbaum.vue';
+
+vi.mock('@/composables/useStammbaumData', () => {
+  return {
+    useStammbaumData: () => ({
+      data: ref(null),
+      pending: ref(true),
+    }),
+  };
+});
+
+describe('KiStammbaum', () => {
+  it('renders heading and loading text', () => {
+    const wrapper = mount(KiStammbaum);
+    expect(wrapper.find('h2').text()).toBe('KI-Stammbaum Visualisierung');
+    expect(wrapper.text()).toContain('Visualisierung lädt...');
+  });
+});

--- a/ki-stammbaum/tests/setup.ts
+++ b/ki-stammbaum/tests/setup.ts
@@ -1,0 +1,5 @@
+import { beforeEach } from 'vitest';
+
+beforeEach(() => {
+  // Add generic setup if needed
+});

--- a/ki-stammbaum/tests/utils/graph-transform.spec.ts
+++ b/ki-stammbaum/tests/utils/graph-transform.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { transformToGraph } from '@/utils/graph-transform';
+import type { Concept } from '@/types/concept';
+
+describe('transformToGraph', () => {
+  it('converts concepts to nodes and links', () => {
+    const concepts: Concept[] = [
+      { id: 'a', name: 'A', year: 1950, description: '', dependencies: [] },
+      { id: 'b', name: 'B', year: 1960, description: '', dependencies: ['a'] },
+    ];
+
+    const graph = transformToGraph(concepts);
+    expect(graph.nodes).toEqual([
+      { id: 'a', year: 1950 },
+      { id: 'b', year: 1960 },
+    ]);
+    expect(graph.links).toEqual([
+      { source: 'a', target: 'b' },
+    ]);
+  });
+
+  it('handles multiple dependencies', () => {
+    const concepts: Concept[] = [
+      { id: 'a', name: 'A', year: 1950, description: '', dependencies: [] },
+      { id: 'b', name: 'B', year: 1960, description: '', dependencies: ['a'] },
+      { id: 'c', name: 'C', year: 1970, description: '', dependencies: ['a', 'b'] },
+    ];
+
+    const { links } = transformToGraph(concepts);
+    expect(links).toEqual([
+      { source: 'a', target: 'b' },
+      { source: 'a', target: 'c' },
+      { source: 'b', target: 'c' },
+    ]);
+  });
+});

--- a/ki-stammbaum/tests/vitest.config.ts
+++ b/ki-stammbaum/tests/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import vue from '@vitejs/plugin-vue';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, '..'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './setup.ts',
+  },
+});


### PR DESCRIPTION
## Summary
- install Vitest, jsdom and Vue test utils
- configure Vitest under `tests/`
- create unit tests for `graph-transform`
- add component tests for `KiStammbaum` and `FilterControls`

## Testing
- `npx vitest --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684aa97566e88329805be3d4b7241d64