### PR TITLE
Fix concept type names

### DIFF
--- a/ki-stammbaum/components/ConceptDetail.vue
+++ b/ki-stammbaum/components/ConceptDetail.vue
@@ -11,8 +11,8 @@
 </template>
 
 <script setup lang="ts">
-// Import des zentralen KiConcept-Typs aus der Typdefinitionsdatei
-import type { KiConcept } from '@/types/concept';
+// Import des zentralen Concept-Typs aus der Typdefinitionsdatei
+import type { Concept } from '@/types/concept';
 // Import der BaseModal-Komponente für die modale Darstellung
 import BaseModal from './ui/BaseModal.vue';
 
@@ -21,7 +21,7 @@ import BaseModal from './ui/BaseModal.vue';
  * concept: Das anzuzeigende KI-Konzept oder null wenn kein Konzept ausgewählt ist
  */
 const props = defineProps<{
-  concept: KiConcept | null;
+  concept: Concept | null;
 }>();
 
 /**

--- a/ki-stammbaum/components/KiStammbaum.vue
+++ b/ki-stammbaum/components/KiStammbaum.vue
@@ -11,8 +11,8 @@
 <script setup lang="ts">
 // Vue Composition API Imports für Lifecycle und Reaktivität
 import { onMounted, ref, watch } from 'vue';
-// Import des zentralen KiConcept-Typs aus der Typdefinitionsdatei
-import type { KiConcept } from '@/types/concept';
+// Import des zentralen Concept-Typs aus der Typdefinitionsdatei
+import type { Concept } from '@/types/concept';
 // Import des Composables zum Laden der Stammbaum-Daten
 import { useStammbaumData } from '@/composables/useStammbaumData';
 
@@ -21,7 +21,7 @@ import { useStammbaumData } from '@/composables/useStammbaumData';
  * conceptSelected: Wird ausgelöst wenn ein Knoten im Stammbaum angeklickt wird
  */
 const emit = defineEmits<{
-  conceptSelected: [concept: KiConcept];
+  conceptSelected: [concept: Concept];
 }>();
 
 // Referenz auf das SVG-Element für D3.js-Manipulationen
@@ -55,7 +55,7 @@ onMounted(() => {
  * 
  * @param concept - Das angeklickte KI-Konzept
  */
-function handleNodeClick(concept: KiConcept): void {
+function handleNodeClick(concept: Concept): void {
   emit('conceptSelected', concept);
 }
 </script>


### PR DESCRIPTION
## Summary
- standardize concept type by replacing KiConcept with Concept

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aabace2dc8329b2e27391f4c864bf