### PR TITLE
Fix stray tokens in TypeScript files

### DIFF
--- a/ki-stammbaum/types/concept.d.ts
+++ b/ki-stammbaum/types/concept.d.ts
@@ -1,6 +1,5 @@
 
 export interface Concept {
- main
   id: string;
   name: string;
   year: number;

--- a/ki-stammbaum/utils/graph-transform.ts
+++ b/ki-stammbaum/utils/graph-transform.ts
@@ -19,7 +19,6 @@ export function transformToGraph(concepts: Concept[]): Graph {
   // 2 Links erstellen – Abhängigkeiten bilden gerichtete Kanten
   const links: Link[] = concepts.flatMap((c) =>
     (c.dependencies ?? []).map((dep) => ({ source: dep, target: c.id })),
- main
   );
   return { nodes, links };
 }


### PR DESCRIPTION
## Summary
- fix `transformToGraph` flatMap closure
- remove stray token from `Concept` interface

## Testing
- `pnpm test` *(fails: Error when fetching pnpm due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684aabac60d483299b286fcdc4ceddf4