### PR TITLE
Add name to Node interface

### DIFF
--- a/ki-stammbaum/tests/utils/graph-transform.spec.ts
+++ b/ki-stammbaum/tests/utils/graph-transform.spec.ts
@@ -11,8 +11,8 @@ describe('transformToGraph', () => {
 
     const graph = transformToGraph(concepts);
     expect(graph.nodes).toEqual([
-      { id: 'a', year: 1950 },
-      { id: 'b', year: 1960 },
+      { id: 'a', name: 'A', year: 1950, description: '' },
+      { id: 'b', name: 'B', year: 1960, description: '' },
     ]);
     expect(graph.links).toEqual([
       { source: 'a', target: 'b' },

--- a/ki-stammbaum/types/concept.d.ts
+++ b/ki-stammbaum/types/concept.d.ts
@@ -9,7 +9,11 @@ export interface Concept {
 
 export interface Node {
   id: string;
+  /** Display name of the concept */
+  name: string;
   year: number;
+  /** Optional description shown in tooltips */
+  description?: string;
 }
 
 export interface Link {

--- a/ki-stammbaum/utils/graph-transform.ts
+++ b/ki-stammbaum/utils/graph-transform.ts
@@ -15,7 +15,12 @@ import type { Concept, Graph, Node, Link } from '../types/concept';
  */
 export function transformToGraph(concepts: Concept[]): Graph {
   // 1 Nodes erstellen – jedes Konzept wird zum Knoten
-  const nodes: Node[] = concepts.map((c) => ({ id: c.id, year: +c.year }));
+  const nodes: Node[] = concepts.map((c) => ({
+    id: c.id,
+    name: c.name,
+    year: +c.year,
+    description: c.description,
+  }));
   // 2 Links erstellen – Abhängigkeiten bilden gerichtete Kanten
   const links: Link[] = concepts.flatMap((c) =>
     (c.dependencies ?? []).map((dep) => ({ source: dep, target: c.id })),


### PR DESCRIPTION
## Summary
- store concept name in Node type
- map name & description in graph-transform
- expect nodes to contain name in graph-transform tests

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_684aafc20fb08329b9a3e657f5638329