### PR TITLE
Handle offline data loading fallback

### DIFF
--- a/ki-stammbaum/README.md
+++ b/ki-stammbaum/README.md
@@ -12,6 +12,12 @@ Abhängigkeiten werden mit pnpm installiert:
 pnpm install
 ```
 
+### Offline-Nutzung
+
+Stellen Sie sicher, dass alle Abhängigkeiten und die Datei `public/data/ki-stammbaum.json`
+lokal verfügbar sind. Die Anwendung lädt die Daten direkt aus dieser Datei und benötigt
+keine Internetverbindung.
+
 ## Entwicklungsserver
 
 Starten Sie den lokalen Server unter `http://localhost:3000`:

--- a/ki-stammbaum/composables/useStammbaumData.ts
+++ b/ki-stammbaum/composables/useStammbaumData.ts
@@ -40,8 +40,14 @@ async function loadData(): Promise<void> {
     const result = await $fetch<StammbaumData>('/data/ki-stammbaum.json');
     dataCache.value = result;
   } catch (err) {
-    // Fehler erfassen und in typisierter Form speichern
-    errorCache.value = err as Error;
+    try {
+      // Fallback auf statischen Import, falls kein Netzwerkzugriff möglich ist
+      const localModule = await import('@/public/data/ki-stammbaum.json');
+      dataCache.value = (localModule.default || localModule) as StammbaumData;
+    } catch {
+      // Fehler erfassen und in typisierter Form speichern
+      errorCache.value = err as Error;
+    }
   } finally {
     // Ladezustand in jedem Fall zurücksetzen
     pendingCache.value = false;


### PR DESCRIPTION
## Summary
- add offline usage note to README
- fall back to static JSON import if fetch fails in useStammbaumData

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab16a2abc83299eecea1629002cb9