### PR TITLE
Add interactive timeline for KI data

### DIFF
--- a/ki-stammbaum/components/Timeline.md
+++ b/ki-stammbaum/components/Timeline.md
@@ -1,0 +1,5 @@
+# Timeline.vue
+
+Visualisiert einen Zeitstrahl von ersten bis letzten Jahr der Daten.
+Balken zeigen an, wie viele Konzepte in einem Jahr existieren. Durch Ziehen
+und Scrollen kann entlang der x-Achse gezoomt und navigiert werden.

--- a/ki-stammbaum/components/Timeline.vue
+++ b/ki-stammbaum/components/Timeline.vue
@@ -1,0 +1,95 @@
+<template>
+  <svg ref="svg" class="timeline-svg" aria-label="Zeitstrahl" />
+</template>
+
+<script setup lang="ts">
+import { onMounted, watch, ref } from 'vue';
+import * as d3 from 'd3';
+import type { Node } from '@/types/concept';
+
+/**
+ * Timeline component visualizing the distribution of nodes over the years.
+ * Allows zooming and panning on the x-axis.
+ */
+const props = defineProps<{ nodes: Node[] }>();
+
+const svg = ref<SVGSVGElement | null>(null);
+
+function render(): void {
+  if (!svg.value || !props.nodes || props.nodes.length === 0) return;
+
+  const svgSel = d3.select(svg.value);
+  svgSel.selectAll('*').remove();
+
+  const width = svg.value.clientWidth || 600;
+  const height = svg.value.clientHeight || 100;
+  const margin = { top: 10, right: 20, bottom: 20, left: 20 };
+
+  const years = props.nodes.map((d) => d.year);
+  const [minYear, maxYear] = d3.extent(years) as [number, number];
+  const counts = d3.rollups(props.nodes, (v) => v.length, (d) => d.year);
+  const countMap = new Map(counts);
+
+  const data = d3.range(minYear, maxYear + 1).map((y) => ({
+    year: y,
+    count: countMap.get(y) ?? 0,
+  }));
+
+  const x = d3.scaleLinear().domain([minYear, maxYear]).range([margin.left, width - margin.right]);
+  const y = d3.scaleLinear().domain([0, d3.max(data, (d) => d.count) ?? 1]).range([height - margin.bottom, margin.top]);
+
+  const g = svgSel.append('g');
+
+  const barWidth = Math.max(1, (width - margin.left - margin.right) / data.length);
+
+  const bars = g
+    .append('g')
+    .attr('class', 'bars')
+    .selectAll('rect')
+    .data(data)
+    .join('rect')
+    .attr('x', (d) => x(d.year) - barWidth / 2)
+    .attr('y', (d) => y(d.count))
+    .attr('width', barWidth)
+    .attr('height', (d) => height - margin.bottom - y(d.count))
+    .attr('fill', '#69b3a2');
+
+  const axis = g
+    .append('g')
+    .attr('class', 'x-axis')
+    .attr('transform', `translate(0,${height - margin.bottom})`)
+    .call(d3.axisBottom(x).ticks(5).tickFormat(d3.format('d')));
+
+  const zoom = d3
+    .zoom<SVGSVGElement, unknown>()
+    .scaleExtent([1, 8])
+    .translateExtent([
+      [margin.left, 0],
+      [width - margin.right, height],
+    ])
+    .on('zoom', (ev) => {
+      const zx = ev.transform.rescaleX(x);
+      bars
+        .attr('x', (d) => zx(d.year) - barWidth / 2)
+        .attr('width', Math.max(1, zx(data[1].year) - zx(data[0].year)));
+      axis.call(d3.axisBottom(zx).ticks(5).tickFormat(d3.format('d')));
+    });
+
+  svgSel.call(zoom as any);
+}
+
+onMounted(render);
+watch(
+  () => props.nodes,
+  () => render(),
+  { deep: true },
+);
+</script>
+
+<style scoped>
+.timeline-svg {
+  width: 100%;
+  height: 100px;
+  cursor: grab;
+}
+</style>

--- a/ki-stammbaum/pages/stammbaum.vue
+++ b/ki-stammbaum/pages/stammbaum.vue
@@ -4,6 +4,7 @@
 
     <FilterControls @filtersApplied="onFilters" />
     <Legend :categories="legendCategories" />
+    <Timeline v-if="graph.nodes.length" :nodes="graph.nodes" />
 
     <div v-if="pending">Daten werden geladen...</div>
     <div v-else-if="error">Fehler beim Laden: {{ error.message }}</div>
@@ -25,6 +26,7 @@ import KiStammbaum from '@/components/KiStammbaum.vue';
 import FilterControls from '@/components/FilterControls.vue';
 import ConceptDetail from '@/components/ConceptDetail.vue';
 import Legend from '@/components/Legend.vue';
+import Timeline from '@/components/Timeline.vue';
 import { useStammbaumData } from '@/composables/useStammbaumData';
 import { transformToGraph } from '@/utils/graph-transform';
 

--- a/ki-stammbaum/tests/components/timeline.spec.ts
+++ b/ki-stammbaum/tests/components/timeline.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import Timeline from '@/components/Timeline.vue';
+
+describe('Timeline', () => {
+  it('renders svg with bars', () => {
+    const wrapper = mount(Timeline, {
+      props: {
+        nodes: [
+          { id: 'a', name: 'A', year: 2000 },
+          { id: 'b', name: 'B', year: 2000 },
+          { id: 'c', name: 'C', year: 2001 },
+        ],
+      },
+    });
+
+    expect(wrapper.find('svg').exists()).toBe(true);
+    // at least one bar should be drawn
+    expect(wrapper.findAll('rect').length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- show events along a time axis via new `Timeline` component
- document `Timeline.vue`
- use timeline on the Stammbaum page
- test that the timeline renders bars

## Testing
- `pnpm test` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_684ab8a7e4748329bcc1033a3878138c