### PR TITLE
Add NodeTimeline component

### DIFF
--- a/ki-stammbaum/components/ConceptDetail.md
+++ b/ki-stammbaum/components/ConceptDetail.md
@@ -1,7 +1,8 @@
 # ConceptDetail.vue
 
-Zeigt Detailinformationen zu einem ausgewählten KI-Konzept an. Ist `concept` nicht gesetzt, 
-erscheint ein Platzhalterhinweis.
+Zeigt Detailinformationen zu einem ausgewählten KI-Konzept. Ist `concept` nicht gesetzt,
+erscheint ein Platzhalterhinweis. Enthält zusätzlich eine kleine Zeitachse
+(`NodeTimeline.vue`), die das Jahr des gewählten Konzepts markiert.
 
 ## Props
 

--- a/ki-stammbaum/components/ConceptDetail.vue
+++ b/ki-stammbaum/components/ConceptDetail.vue
@@ -5,6 +5,7 @@
       <p><strong>Name:</strong> {{ concept.name }}</p>
       <p><strong>Jahr:</strong> {{ concept.year }}</p>
       <p><strong>Beschreibung:</strong> {{ concept.description }}</p>
+      <NodeTimeline :concept="concept" />
       <button class="close-button" type="button" @click="close">Schließen</button>
     </div>
   </BaseModal>
@@ -15,6 +16,7 @@
 import type { Concept } from '@/types/concept';
 // Import der BaseModal-Komponente für die modale Darstellung
 import BaseModal from './ui/BaseModal.vue';
+import NodeTimeline from './NodeTimeline.vue';
 
 /**
  * Props-Definition für die Komponente

--- a/ki-stammbaum/components/NodeTimeline.md
+++ b/ki-stammbaum/components/NodeTimeline.md
@@ -1,0 +1,7 @@
+# NodeTimeline.vue
+
+Zeigt eine kurze horizontale Zeitachse und hebt das Jahr eines ausgewählten Konzepts hervor.
+
+## Props
+
+- `concept` *(object | null)* – das aktuell ausgewählte Konzept.

--- a/ki-stammbaum/components/NodeTimeline.vue
+++ b/ki-stammbaum/components/NodeTimeline.vue
@@ -1,0 +1,63 @@
+<template>
+  <svg ref="svg" class="node-timeline-svg" aria-label="Jahresanzeige" />
+</template>
+
+<script setup lang="ts">
+import { onMounted, watch, ref } from 'vue';
+import * as d3 from 'd3';
+import type { Concept } from '@/types/concept';
+
+const props = defineProps<{ concept: Concept | null }>();
+const svg = ref<SVGSVGElement | null>(null);
+
+function render(): void {
+  if (!svg.value || !props.concept) return;
+
+  const year = props.concept.year;
+  const range: [number, number] = [year - 5, year + 5];
+
+  const svgSel = d3.select(svg.value);
+  svgSel.selectAll('*').remove();
+
+  const width = svg.value.clientWidth || 300;
+  const height = 40;
+  const margin = { top: 5, right: 10, bottom: 20, left: 10 };
+
+  svgSel
+    .attr('viewBox', `0 0 ${width} ${height}`)
+    .attr('preserveAspectRatio', 'xMidYMid meet');
+
+  const x = d3
+    .scaleLinear()
+    .domain(range)
+    .range([margin.left, width - margin.right]);
+
+  svgSel
+    .append('g')
+    .attr('transform', `translate(0,${height - margin.bottom})`)
+    .call(d3.axisBottom(x).ticks(5).tickFormat(d3.format('d')));
+
+  svgSel
+    .append('line')
+    .attr('x1', x(year))
+    .attr('x2', x(year))
+    .attr('y1', margin.top)
+    .attr('y2', height - margin.bottom)
+    .attr('stroke', 'red')
+    .attr('stroke-width', 2);
+}
+
+onMounted(render);
+watch(
+  () => props.concept,
+  render,
+  { deep: true },
+);
+</script>
+
+<style scoped>
+.node-timeline-svg {
+  width: 100%;
+  height: 40px;
+}
+</style>

--- a/ki-stammbaum/tests/components/node-timeline.spec.ts
+++ b/ki-stammbaum/tests/components/node-timeline.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import NodeTimeline from '@/components/NodeTimeline.vue';
+
+const concept = {
+  id: 'c1',
+  name: 'Test',
+  year: 2000,
+  description: '',
+  dependencies: [],
+};
+
+describe('NodeTimeline', () => {
+  it('renders svg when concept is provided', () => {
+    const wrapper = mount(NodeTimeline, {
+      props: { concept },
+    });
+    expect(wrapper.find('svg').exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- display a short axis highlighting the selected year via new `NodeTimeline.vue`
- embed `NodeTimeline` within `ConceptDetail.vue`
- document timeline addition in `ConceptDetail.md`
- add a `NodeTimeline` readme
- test that `NodeTimeline` renders an SVG

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684abe1da3908329a77717a4df2abd88