### PR TITLE
Implement zoom-based binning for Timeline

### DIFF
--- a/ki-stammbaum/components/Timeline.md
+++ b/ki-stammbaum/components/Timeline.md
@@ -5,3 +5,13 @@ Balken zeigen an, wie viele Konzepte in einem Jahr existieren. Durch Ziehen
 und Scrollen kann entlang der x-Achse gezoomt und navigiert werden.
 Der sichtbare Jahresbereich wird als `rangeChanged`-Event ausgegeben und kann
 zum Filtern der Stammbaum-Visualisierung genutzt werden.
+
+Abhängig vom aktuellen Zoomfaktor werden die Werte vor dem Rendern in
+verschiedene Zeitabschnitte gruppiert:
+
+- **Zoom < 1.5:** Jahrzehnte
+- **1.5 ≤ Zoom < 3:** Fünf-Jahres-Intervalle
+- **Zoom ≥ 3:** Einzelne Jahre
+
+Bei jeder Zoom-Interaktion wird die Skalierung gespeichert und die
+Balkendarstellung entsprechend neu berechnet.

--- a/ki-stammbaum/tests/components/timeline.spec.ts
+++ b/ki-stammbaum/tests/components/timeline.spec.ts
@@ -33,4 +33,23 @@ describe('Timeline', () => {
     const [range] = events![0];
     expect(range).toEqual([2000, 2002]);
   });
+
+  it('changes number of bars when zoomed', async () => {
+    const nodes = Array.from({ length: 20 }, (_, i) => ({
+      id: `n${i}`,
+      name: `N${i}`,
+      year: 1990 + i,
+    }));
+
+    const wrapper = mount(Timeline, { props: { nodes } });
+
+    const initialBars = wrapper.findAll('rect').length;
+    expect(initialBars).toBe(2);
+
+    (wrapper.vm as any).applyZoom(4);
+    await wrapper.vm.$nextTick();
+
+    const zoomedBars = wrapper.findAll('rect').length;
+    expect(zoomedBars).toBeGreaterThan(initialBars);
+  });
 });


### PR DESCRIPTION
## Summary
- track zoom scale inside Timeline.vue
- bin timeline data by decade/five‑year/year depending on zoom level
- expose a `applyZoom` method for tests
- re-render bars after zoom changes
- document zoom thresholds in Timeline.md
- test bar counts at different zoom levels

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684abe211e70832995690a106765b17e