### PR TITLE
Implement resize observer for responsive D3 rendering

### DIFF
--- a/ki-stammbaum/components/KiStammbaum.vue
+++ b/ki-stammbaum/components/KiStammbaum.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ki-stammbaum-container">
+  <div class="ki-stammbaum-container" ref="container">
     <h2>KI-Stammbaum Visualisierung</h2>
     <svg
       ref="svg"
@@ -54,6 +54,8 @@ const emit = defineEmits<{
  * Wird verwendet, um das DOM-Element direkt mit D3.js zu steuern
  */
 const svg = ref<SVGSVGElement | null>(null);
+const container = ref<HTMLElement | null>(null);
+let resizeObserver: ResizeObserver | null = null;
 
 /** Aktuelle D3-Simulation zur späteren Bereinigung */
 let simulation: d3.Simulation<GraphNode, undefined> | null = null;
@@ -196,10 +198,17 @@ function render(): void {
 
 // Komponente nach dem Mounting rendern
 
-onMounted(render);
+onMounted(() => {
+  render();
+  resizeObserver = new ResizeObserver(() => render());
+  if (container.value) resizeObserver.observe(container.value);
+});
 
-// Simulation beim Unmount stoppen, um Speicherlecks zu vermeiden
-onBeforeUnmount(() => simulation?.stop());
+// Simulation und ResizeObserver beim Unmount stoppen, um Speicherlecks zu vermeiden
+onBeforeUnmount(() => {
+  simulation?.stop();
+  resizeObserver?.disconnect();
+});
 
 // Bei Änderungen der Props neu rendern
 watch(

--- a/ki-stammbaum/components/Timeline.vue
+++ b/ki-stammbaum/components/Timeline.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, watch, ref, nextTick, defineExpose } from 'vue';
+import { onMounted, onBeforeUnmount, watch, ref, nextTick, defineExpose } from 'vue';
 import * as d3 from 'd3';
 import type { Node } from '@/types/concept';
 
@@ -27,6 +27,7 @@ const emit = defineEmits<{
 }>();
 
 const svg = ref<SVGSVGElement | null>(null);
+let resizeObserver: ResizeObserver | null = null;
 
 /** Aktueller Zoomfaktor der Timeline */
 const zoomScale = ref(1);
@@ -163,8 +164,13 @@ function applyZoom(scale: number) {
 }
 
 defineExpose({ applyZoom, zoomScale });
+onMounted(() => {
+  render();
+  resizeObserver = new ResizeObserver(() => render());
+  if (svg.value) resizeObserver.observe(svg.value);
+});
 
-onMounted(render);
+onBeforeUnmount(() => resizeObserver?.disconnect());
 watch(
   () => props.nodes,
   async () => {


### PR DESCRIPTION
## Summary
- respond to container size changes in `Timeline.vue`
- observe SVG container for `KiStammbaum.vue`
- clean up observers on component unmount

## Testing
- `npm run lint` *(fails: cannot find package 'globals')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac2f895f48329885e5c2e4835baf4