### PR TITLE
feat: Adjust KiStammbaum container for dynamic sizing and spacing

### DIFF
--- a/ki-stammbaum/components/KiStammbaum.vue
+++ b/ki-stammbaum/components/KiStammbaum.vue
@@ -525,7 +525,9 @@
 
 <style scoped>
   .ki-stammbaum-container {
-    width: 100%;
+    width: auto;
+    margin-left: 20px;
+    margin-right: 20px;
     height: 80vh;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
I modified the CSS for the `.ki-stammbaum-container` in `KiStammbaum.vue` to improve its dynamic sizing and ensure consistent spacing from browser edges.

Changes:
- Set `width: auto;`
- Added `margin-left: 20px;` and `margin-right: 20px;`

These changes allow the container to dynamically adjust its width based on the parent element, while maintaining explicit horizontal margins. Combined with the existing `height: 80vh` and the parent page's padding, this provides better control over the container's spacing relative to the viewport. The internal `padding: 20px` is preserved.